### PR TITLE
feat: Added support for XRD only output

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Download the `.exe` file and add it to your `PATH`
 ## Usage
 Currently xDocs supports only markdown output, but more in pipeline. To generate markdown docs for your compositions & XRDs
 ```bash
-crossplane-docs md [INPUT_PATH|INPUT_FILE] -o [OUTPUT_FILE]
+# Generate markdown docs for given compositions and XRDs
+crossplane-docs md [INPUT_PATH] -o [OUTPUT_FILE]
+
+# In some cases users prefer to generate XRD docs since pipeline mode is not supported
+crossplane-docs md [INPUT_PATH] -o [OUTPUT_FILE] --xrd-only
 ```
 For example:
 ```bash
@@ -41,6 +45,7 @@ Check [README.md](./samples/README.md) for the output.
 ## Features
 - Discovers Composition & its resources, XR, XRD and Claim names with their references
 - Markdown ouput with tabulation
+- Supports generating only XRD docs
 - Claim/XRC specifications (WIP)
 
 ## Limitations

--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -5,7 +5,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var outputFileName string
+var (
+	outputFileName string
+	printXRDOnly   bool
+)
 
 // NewCmdMarkdown drives the markdown command for x-docs
 func NewCmdMarkdown() *cobra.Command {
@@ -25,6 +28,7 @@ crossplane-docs markdown ./samples -o samples/README.md
 
 	// flags
 	cmd.Flags().StringVarP(&outputFileName, "output-file", "o", "xDocs.md", "Filename used for markdown docs output")
+	cmd.Flags().BoolVarP(&printXRDOnly, "xrd-only", "", false, "Output only XRD specifications")
 
 	return cmd
 }

--- a/pkg/templates.go
+++ b/pkg/templates.go
@@ -27,3 +27,21 @@ var markdownGenericTemplate = `
 {{- end }}
 {{- end }}
 `
+
+var markdownXRDOnlyTemplate = `
+{{- range . }}
+### {{ .Name }}
+| Name | Claim |
+|------|-------|
+| {{ .Name }} | {{ .ClaimNameKind }} |
+#### Specs
+{{- range .Versions }}
+##### Version: {{ .Version }}
+| Field | Path | Type | Description | Required |
+|------|-------|------|-------|-------|
+{{- range .XRDSpec }}
+| {{ .FieldName }} | {{ .Path }} | {{ .Type }} | {{ .Description }} | {{ .Required }} |
+{{- end }}
+{{- end }}
+{{- end }}
+`

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -1,5 +1,11 @@
 package pkg
 
+type OutputOpts struct {
+	OutputFileName string
+	OutputTemplate string
+	PrintXRDOnly   bool
+}
+
 type CompResourceData struct {
 	Name       string
 	Kind       string
@@ -29,8 +35,8 @@ type CompResourceDefinitionData struct {
 	Versions              []XRDVersion
 }
 
-// MarkdownOutputData output data struct used by markdown generator
-type MarkdownOutputData struct {
+// GenericOutputData output data struct used by markdown generator
+type GenericOutputData struct {
 	CompositionName string
 	XRAPIVersion    string
 	XRKind          string

--- a/samples/XRDS.md
+++ b/samples/XRDS.md
@@ -1,0 +1,14 @@
+
+### xjetpostgresqls.database.wk
+| Name | Claim |
+|------|-------|
+| xjetpostgresqls.database.wk | JetPostgreSQL |
+#### Specs
+##### Version: v1alpha1
+| Field | Path | Type | Description | Required |
+|------|-------|------|-------|-------|
+| spec |  | object | Required spec field for your API | false |
+| parameters | spec | object |  | true |
+| dbName | spec.parameters | string | name of the new DB inside the DB instance - string | true |
+| instanceSize | spec.parameters | string | instance size - string | true |
+| storageGB | spec.parameters | integer | size of the Database in GB - integer | true |


### PR DESCRIPTION
Previously we don't generate docs if there is no link between the compositions and XRDs. Now to solve that problem `--xrd-only` flag is introduced to generate only docs for XRDs if needed. This will be useful for pipeline mode compositions as well, as users might expect only XRD docs since we don't support pipeline mode compositions.

Solves: #7 