### PR TITLE
feat: Added Inputs and Outputs as seperate docs for XRDs

### DIFF
--- a/pkg/templates.go
+++ b/pkg/templates.go
@@ -13,9 +13,16 @@ var markdownGenericTemplate = `
 #### XRD Spec
 {{- range .LinkedXRD.Versions }}
 ##### Version: {{ .Version }}
+##### Inputs
 | Field | Path | Type | Description | Default | Required |
 |------|-------|------|-------|-------|-------|
-{{- range .XRDSpec }}
+{{- range .XRDInputSpec }}
+| {{ .FieldName }} | {{ .Path }} | {{ .Type }} | {{ .Description }} | {{ .Default }} | {{ .Required }} |
+{{- end }}
+##### Outputs
+| Field | Path | Type | Description | Default | Required |
+|------|-------|------|-------|-------|-------|
+{{- range .XRDOutputSpec }}
 | {{ .FieldName }} | {{ .Path }} | {{ .Type }} | {{ .Description }} | {{ .Default }} | {{ .Required }} |
 {{- end }}
 {{- end }}
@@ -37,9 +44,16 @@ var markdownXRDOnlyTemplate = `
 #### Specs
 {{- range .Versions }}
 ##### Version: {{ .Version }}
+##### Inputs
 | Field | Path | Type | Description | Default |  Required |
 |------|-------|------|-------|-------|-------|
-{{- range .XRDSpec }}
+{{- range .XRDInputSpec }}
+| {{ .FieldName }} | {{ .Path }} | {{ .Type }} | {{ .Description }} | {{ .Default }} | {{ .Required }} |
+{{- end }}
+##### Outputs
+| Field | Path | Type | Description | Default |  Required |
+|------|-------|------|-------|-------|-------|
+{{- range .XRDOutputSpec }}
 | {{ .FieldName }} | {{ .Path }} | {{ .Type }} | {{ .Description }} | {{ .Default }} | {{ .Required }} |
 {{- end }}
 {{- end }}

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -24,8 +24,9 @@ type XRDSpecData struct {
 
 // XRDVersion used for representing individual API versions
 type XRDVersion struct {
-	Version string
-	XRDSpec []XRDSpecData
+	Version       string
+	XRDInputSpec  []XRDSpecData
+	XRDOutputSpec []XRDSpecData
 }
 
 // CompResourceDefinitionData defines the XRD data and its XR, XRC details if any

--- a/samples/README.md
+++ b/samples/README.md
@@ -9,6 +9,7 @@
 | xjetpostgresqls.database.wk | JetPostgreSQL |
 #### XRD Spec
 ##### Version: v1alpha1
+##### Inputs
 | Field | Path | Type | Description | Default | Required |
 |------|-------|------|-------|-------|-------|
 | spec |  | object | Required spec field for your API | n/a | false |
@@ -16,6 +17,13 @@
 | dbName | spec.parameters | string | name of the new DB inside the DB instance - string | n/a | true |
 | instanceSize | spec.parameters | string | instance size - string | "large" | true |
 | storageGB | spec.parameters | integer | size of the Database in GB - integer | 2 | true |
+##### Outputs
+| Field | Path | Type | Description | Default | Required |
+|------|-------|------|-------|-------|-------|
+| status |  | object |  | n/a | false |
+| dbConnectionURL | status | string | String that contains the URL of the Database connection | n/a | false |
+| status | status | string | Status of the Database itself | n/a | false |
+| upgradeEligibility | status | boolean | Flag to check eligibility for DB upgrade | n/a | false |
 #### Resources
 | Name | Kind | API Version |
 |------|------|-------------|

--- a/samples/XRDS.md
+++ b/samples/XRDS.md
@@ -5,10 +5,18 @@
 | xjetpostgresqls.database.wk | JetPostgreSQL |
 #### Specs
 ##### Version: v1alpha1
+##### Inputs
 | Field | Path | Type | Description | Default |  Required |
 |------|-------|------|-------|-------|-------|
 | spec |  | object | Required spec field for your API | n/a | false |
 | parameters | spec | object |  | n/a | true |
+| dbName | spec.parameters | string | name of the new DB inside the DB instance - string | n/a | true |
 | instanceSize | spec.parameters | string | instance size - string | "large" | true |
 | storageGB | spec.parameters | integer | size of the Database in GB - integer | 2 | true |
-| dbName | spec.parameters | string | name of the new DB inside the DB instance - string | n/a | true |
+##### Outputs
+| Field | Path | Type | Description | Default |  Required |
+|------|-------|------|-------|-------|-------|
+| status |  | object |  | n/a | false |
+| dbConnectionURL | status | string | String that contains the URL of the Database connection | n/a | false |
+| status | status | string | Status of the Database itself | n/a | false |
+| upgradeEligibility | status | boolean | Flag to check eligibility for DB upgrade | n/a | false |

--- a/samples/sample-xrd.yaml
+++ b/samples/sample-xrd.yaml
@@ -46,3 +46,15 @@ spec:
                     - instanceSize
               required:
                 - parameters
+            status:
+              type: object
+              properties:
+                dbConnectionURL:
+                  description: String that contains the URL of the Database connection
+                  type: string
+                status:
+                  description: Status of the Database itself
+                  type: string
+                upgradeEligibility:
+                  description: Flag to check eligibility for DB upgrade
+                  type: boolean


### PR DESCRIPTION
Seperated `Inputs` & `Outputs` for XRD specs. Now generator will look for `status` field in XRD and tabulate as output

Closes #9 